### PR TITLE
Pagination

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,8 @@ Rest API change log
 
 ## ?.?.? / ????-??-??
 
+* Added `@$req: request` to pass complete request object - @thekid
+
 ## 0.2.0 / 2018-02-13
 
 * Restored HHVM support - @thekid

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Method parameters are automatically extracted from URI segments if their name ma
 * `@$attributes: entity` will deserialize the request body and pass its value to $attributes
 * `@$upload: stream` will pass an `io.streams.InputStream` instance to stream the request body to $upload
 * `@$bytes: body` will pass the request body as a string
+* `@$req: request` will pass the complete request object
 
 
 Return types

--- a/src/main/php/web/rest/Delegate.class.php
+++ b/src/main/php/web/rest/Delegate.class.php
@@ -35,6 +35,9 @@ class Delegate {
       'entity'   => function($req, $format, $name) {
         return $format->read($req, $name);
       },
+      'request'  => function($req, $format, $name) {
+        return $req;
+      },
       'default'  => function($req, $format, $name) {
         if (null !== ($v= $req->param($name))) {
           return $v;

--- a/src/main/php/web/rest/Response.class.php
+++ b/src/main/php/web/rest/Response.class.php
@@ -110,7 +110,7 @@ class Response {
    * @param  int $code
    * @return self
    */
-  private static function status($code) {
+  public static function status($code) {
     return new self($code);
   }
 

--- a/src/main/php/web/rest/paging/Behavior.class.php
+++ b/src/main/php/web/rest/paging/Behavior.class.php
@@ -1,0 +1,49 @@
+<?php namespace web\rest\paging;
+
+interface Behavior {
+
+  /**
+   * Returns whether this behavior paginates a given request
+   *
+   * @param  web.Request $request
+   * @return bool
+   */
+  public function paginates($request);
+
+  /**
+   * Returns the starting offset set via the request
+   *
+   * @param  web.Request $request
+   * @param  int $size
+   * @return var The offset or NULL if the parameter was omitted
+   */
+  public function start($request, $size);
+
+  /**
+   * Returns the ending offset set via the request
+   *
+   * @param  web.Request $request
+   * @param  int $size
+   * @return var The offset or NULL if the parameter was omitted
+   */
+  public function end($request, $size);
+
+  /**
+   * Returns a limit set via the request
+   *
+   * @param  web.Request $request
+   * @param  int $size
+   * @return int The limit or NULL if the parameter was omitted
+   */
+  public function limit($request, $size);
+
+  /**
+   * Paginate
+   *
+   * @param  web.Request $request
+   * @param  web.rest.Response $response
+   * @param  bool $last
+   * @return web.rest.Response
+   */
+  public function paginate($request, $response, $last);
+}

--- a/src/main/php/web/rest/paging/LinkHeader.class.php
+++ b/src/main/php/web/rest/paging/LinkHeader.class.php
@@ -1,0 +1,39 @@
+<?php namespace web\rest\paging;
+
+use util\URI;
+
+/**
+ * Wraps a "Link" header
+ *
+ * @see   http://tools.ietf.org/html/rfc5988#page-6
+ */
+class LinkHeader {
+  private $links= [];
+
+  /**
+   * Creates a new "Link" header
+   *
+   * @param  [:var] $links A map of rel -> url
+   */
+  public function __construct($links) {
+    foreach ($links as $rel => $link) {
+      if ($link instanceof URI) {
+        $this->links[$rel]= $link;
+      } else if ($link) {
+        $this->links[$rel]= new URI($link);
+      }
+    }
+  }
+
+  /** @return bool */
+  public function present() { return !empty($this->links); }
+
+  /** @return string */
+  public function __toString() {
+    $return= '';
+    foreach ($this->links as $rel => $link) {
+      $return.= ', <'.$link->getURL().'>; rel="'.$rel.'"';
+    }
+    return (string)substr($return, 2);
+  }
+}

--- a/src/main/php/web/rest/paging/LinkHeader.class.php
+++ b/src/main/php/web/rest/paging/LinkHeader.class.php
@@ -1,5 +1,6 @@
 <?php namespace web\rest\paging;
 
+use lang\Value;
 use util\URI;
 
 /**
@@ -7,7 +8,7 @@ use util\URI;
  *
  * @see   http://tools.ietf.org/html/rfc5988#page-6
  */
-class LinkHeader {
+class LinkHeader implements Value {
   private $links= [];
 
   /**
@@ -32,8 +33,24 @@ class LinkHeader {
   public function __toString() {
     $return= '';
     foreach ($this->links as $rel => $link) {
-      $return.= ', <'.$link->getURL().'>; rel="'.$rel.'"';
+      $return.= ', <'.(string)$link.'>; rel="'.$rel.'"';
     }
     return (string)substr($return, 2);
+  }
+
+  /** @return string */
+  public function hashCode() { return md5($this->__toString()); }
+
+  /** @return string */
+  public function toString() { return nameof($this).'('.$this->__toString().')'; }
+
+  /**
+   * Compare
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? strcmp($this->__toString(), $value->__toString()) : 1;
   }
 }

--- a/src/main/php/web/rest/paging/PageParameters.class.php
+++ b/src/main/php/web/rest/paging/PageParameters.class.php
@@ -1,0 +1,99 @@
+<?php namespace web\rest\paging;
+
+/**
+ * The URL parameters paging behavior uses two parameters from the request's
+ * query string to determine page and limit. When the parameter referrning to
+ * the current page is omitted from the URL this behavior regards this as the
+ * first page. The limit can be used to overwrite the default paging limit set
+ * via the `Paging` class.
+ */
+class PageParameters implements Behavior {
+  private $page, $limit;
+
+  /**
+   * Creates a new parameters instance
+   *
+   * @param  string $page Name of parameter referring to the current page
+   * @param  string $page Name of parameter referring to the optional limit
+   */
+  public function __construct($page, $limit) {
+    $this->page= $page;
+    $this->limit= $limit;
+  }
+
+  /**
+   * Returns URL with a given page
+   *
+   * @param  web.Request $request
+   * @param  int $page
+   * @return util.URI
+   */
+  private function uriOf($request, $page) {
+    return $request->uri()->using()->param($this->page, $page)->create();
+  }
+
+  /**
+   * Returns whether this behavior paginates a given request. Always returns true,
+   * as omitting the page and limit parameters will paginate with the defaults!
+   *
+   * @param  web.Request $request
+   * @return bool
+   */
+  public function paginates($request) { return true; }
+
+  /**
+   * Returns the starting offset set via the request, or NULL if none was given.
+   *
+   * @param  web.Request $request
+   * @param  int $size
+   * @return var
+   */
+  public function start($request, $size) {
+    $page= $request->param($this->page, null);
+    return null === $page ? null : ($page - 1) * $this->limit($request, $size);
+  }
+
+  /**
+   * Returns the ending offset set via the request
+   *
+   * @param  web.Request $request
+   * @param  int $size
+   * @return var The offset or NULL if the parameter was omitted
+   */
+  public function end($request, $size) {
+    return $this->start($request, $size) + $this->limit($request, $size);
+  }
+
+  /**
+   * Returns the current limit
+   *
+   * @param  web.Request $request
+   * @param  int $size
+   * @return int
+   */
+  public function limit($request, $size) {
+    return (int)$request->param($this->limit, $size);
+  }
+
+  /**
+   * Paginate
+   *
+   * @param  web.Request $request
+   * @param  web.rest.Response $response
+   * @param  bool $last
+   * @return web.rest.Response
+   */
+  public function paginate($request, $response, $last) {
+    $page= $request->param($this->page, 1);
+    $header= new LinkHeader([
+      'prev' => $page > 1 ? $this->uriOf($request, $page - 1) : null,
+      'next' => $last ? null : $this->uriOf($request, $page + 1)
+    ]);
+
+    if ($header->present()) {
+      return $response->header('Link', $header);
+    } else {
+      return $response;
+    }
+  }
+}

--- a/src/main/php/web/rest/paging/PageParameters.class.php
+++ b/src/main/php/web/rest/paging/PageParameters.class.php
@@ -6,6 +6,8 @@
  * the current page is omitted from the URL this behavior regards this as the
  * first page. The limit can be used to overwrite the default paging limit set
  * via the `Paging` class.
+ *
+ * @test  xp://web.rest.unittest.paging.PageParametersTest
  */
 class PageParameters implements Behavior {
   private $page, $limit;

--- a/src/main/php/web/rest/paging/Pagination.class.php
+++ b/src/main/php/web/rest/paging/Pagination.class.php
@@ -7,6 +7,8 @@ use web\rest\Response;
  * A pagination instance holds the paging behavior, the request and the
  * page size. It is created by passing a request instance to the Paging
  * class' `on()` method.
+ *
+ * @test  xp://web.rest.unittest.paging.PaginationTest
  */
 class Pagination {
   private $request, $size, $behavior;
@@ -61,21 +63,24 @@ class Pagination {
    * @return web.rest.Response
    */
   public function paginate($iterable, $res= 200) {
+    $limit= $this->limit();
+
+    // Trim excess elements if necessary
     if ($iterable instanceof \Traversable) {
       $elements= [];
+      $i= 0;
       foreach ($iterable as $value) {
         $elements[]= $value;
+        if (++$i >= $limit) break;
       }
     } else {
       $elements= (array)$iterable;      
+      while (sizeof($elements) > $limit) {
+        array_pop($elements);
+      }
     }
 
-    $limit= $this->limit();
     $last= sizeof($elements) <= $limit;
-    while (sizeof($elements) > $limit) {
-      array_pop($elements);
-    }
-
     $response= $res instanceof Response ? $res : Response::status($res);
     return $this->behavior->paginate($this->request, $response->entity($elements), $last);
   }

--- a/src/main/php/web/rest/paging/Pagination.class.php
+++ b/src/main/php/web/rest/paging/Pagination.class.php
@@ -1,6 +1,7 @@
 <?php namespace web\rest\paging;
 
 use web\Request;
+use web\rest\Response;
 
 /**
  * A pagination instance holds the paging behavior, the request and the
@@ -55,11 +56,11 @@ class Pagination {
   /**
    * Paginate
    *
-   * @param  web.rest.Response $response
    * @param  var[]|iterable $iterable
+   * @param  int|web.rest.Response $res
    * @return web.rest.Response
    */
-  public function paginate($response, $iterable) {
+  public function paginate($iterable, $res= 200) {
     if ($iterable instanceof \Traversable) {
       $elements= [];
       foreach ($iterable as $value) {
@@ -75,6 +76,7 @@ class Pagination {
       array_pop($elements);
     }
 
-    return $this->behavior->paginate($this->request, $response, $last)->entity($elements);
+    $response= $res instanceof Response ? $res : Response::status($res);
+    return $this->behavior->paginate($this->request, $response->entity($elements), $last);
   }
 }

--- a/src/main/php/web/rest/paging/Pagination.class.php
+++ b/src/main/php/web/rest/paging/Pagination.class.php
@@ -1,0 +1,80 @@
+<?php namespace web\rest\paging;
+
+use web\Request;
+
+/**
+ * A pagination instance holds the paging behavior, the request and the
+ * page size. It is created by passing a request instance to the Paging
+ * class' `on()` method.
+ */
+class Pagination {
+  private $request, $size, $behavior;
+
+  /**
+   * Creates a new pagination instance
+   *
+   * @param  web.Request $request
+   * @param  web.rest.paging.Behavior $behavior
+   * @param  int $size
+   */
+  public function __construct(Request $request, $behavior, $size) {
+    $this->request= $request;
+    $this->size= $size;
+    $this->behavior= $behavior;
+  }
+
+  /**
+   * Returns the starting offset, or the supplied default of omitted
+   *
+   * @param  var $default
+   * @return var
+   */
+  public function start($default= null) {
+    return $this->behavior->start($this->request, $this->size) ?: $default;
+  }
+
+  /**
+   * Returns the ending offset, or the supplied default of omitted
+   *
+   * @param  var $default
+   * @return var
+   */
+  public function end($default= null) {
+    return $this->behavior->end($this->request, $this->size) ?: $default;
+  }
+
+  /**
+   * Returns the limit passed in the request's limit paramenter, or the default limit of omitted
+   *
+   * @return int
+   */
+  public function limit() {
+    return $this->behavior->limit($this->request, $this->size);
+  }
+
+  /**
+   * Paginate
+   *
+   * @param  web.rest.Response $response
+   * @param  var[]|iterable $iterable
+   * @return web.rest.Response
+   */
+  public function paginate($response, $iterable) {
+    if ($iterable instanceof \Traversable) {
+      $elements= [];
+      foreach ($iterable as $value) {
+        $elements[]= $value;
+      }
+    } else {
+      $elements= (array)$iterable;      
+    }
+
+    $limit= $this->limit();
+    $last= sizeof($elements) <= $limit;
+    while (sizeof($elements) > $limit) {
+      array_pop($elements);
+    }
+
+    return $this->behavior->paginate($this->request, $response, $last)->entity($elements);
+  }
+}

--- a/src/main/php/web/rest/paging/Paging.class.php
+++ b/src/main/php/web/rest/paging/Paging.class.php
@@ -1,0 +1,33 @@
+<?php namespace web\rest\paging;
+
+use util\NoSuchElementException;
+
+class Paging {
+  private $size, $behaviors;
+
+  /**
+   * Creates a new paging instance
+   *
+   * @param  int $size
+   * @param  web.rest.paging.Behavior[] $behaviors
+   */
+  public function __construct($size, array $behaviors) {
+    $this->size= $size;
+    $this->behaviors= $behaviors;
+  }
+
+  /**
+   * Paging
+   *
+   * @param  web.Request $request
+   * @return web.rest.paging.Pagination
+   * @throws util.NoSuchElementException
+   */
+  public function on($request) {
+    foreach ($this->behaviors as $behavior) {
+      if ($behavior->paginates($request)) return new Pagination($request, $behavior, $this->size);
+    }
+
+    throw new NoSuchElementException('No pagination behavior applies to the request');
+  }
+}

--- a/src/test/php/web/rest/unittest/paging/PageParametersTest.class.php
+++ b/src/test/php/web/rest/unittest/paging/PageParametersTest.class.php
@@ -1,0 +1,124 @@
+<?php namespace web\rest\unittest\paging;
+
+use web\rest\Response;
+use web\rest\paging\PageParameters;
+use web\rest\paging\LinkHeader;
+use web\Request;
+use web\io\TestInput;
+
+class PageParametersTest extends \unittest\TestCase {
+  const SIZE = 20;
+
+  private $fixture;
+
+  /**
+   * Creates a new request instance
+   *
+   * @param  string $queryString
+   * @return web.Request
+   */
+  private function newRequest($queryString= '') {
+    return new Request(new TestInput('GET', '/'.$queryString));
+  }
+
+  /**
+   * Creates fixture
+   *
+   * @return void
+   */
+  public function setUp() {
+    $this->fixture= new PageParameters('page', 'per_page');
+  }
+
+  #[@test]
+  public function paginates() {
+    $this->assertTrue($this->fixture->paginates($this->newRequest()));
+  }
+
+  #[@test]
+  public function start_for_empty_request() {
+    $this->assertNull($this->fixture->start($this->newRequest(), self::SIZE));
+  }
+
+  #[@test]
+  public function start_in_request() {
+    $this->assertEquals(0, $this->fixture->start($this->newRequest('?page=1'), self::SIZE));
+  }
+
+  #[@test]
+  public function end_for_empty_request() {
+    $this->assertEquals(self::SIZE, $this->fixture->end($this->newRequest(), self::SIZE));
+  }
+
+  #[@test]
+  public function end_via_limit_in_request() {
+    $this->assertEquals(10, $this->fixture->end($this->newRequest('?page=2&per_page=5'), self::SIZE));
+  }
+
+  #[@test]
+  public function limit_for_empty_request() {
+    $this->assertEquals(self::SIZE, $this->fixture->limit($this->newRequest(), self::SIZE));
+  }
+
+  #[@test]
+  public function limit_in_request() {
+    $this->assertEquals(5, $this->fixture->limit($this->newRequest('?per_page=5'), self::SIZE));
+  }
+
+  #[@test]
+  public function no_headers_when_first_page_is_also_last_page() {
+    $response= newinstance(Response::class, [], [
+      '__construct' => function() { /* Shadow parent */ },
+      'header'      => function($name, $value) use(&$headers) { $headers[$name]= $value; }
+    ]);
+
+    $headers= [];
+    $this->fixture->paginate($this->newRequest('?page=1'), $response, true);
+    $this->assertEquals([], $headers);
+  }
+
+  #[@test]
+  public function next_header_on_first_page() {
+    $response= newinstance(Response::class, [], [
+      '__construct' => function() { /* Shadow parent */ },
+      'header'      => function($name, $value) use(&$headers) { $headers[$name]= $value; }
+    ]);
+
+    $headers= [];
+    $this->fixture->paginate($this->newRequest('?page=1'), $response, false);
+    $this->assertEquals(
+      ['Link' => new LinkHeader(['next' => 'http://localhost/?page=2'])],
+      $headers
+    );
+  }
+
+  #[@test]
+  public function next_and_prev_header_on_second_page() {
+    $response= newinstance(Response::class, [], [
+      '__construct' => function() { /* Shadow parent */ },
+      'header'      => function($name, $value) use(&$headers) { $headers[$name]= $value; }
+    ]);
+
+    $headers= [];
+    $this->fixture->paginate($this->newRequest('?page=2'), $response, false);
+    $this->assertEquals(
+      ['Link' => new LinkHeader(['prev' => 'http://localhost/?page=1', 'next' => 'http://localhost/?page=3'])],
+      $headers
+    );
+  }
+
+  #[@test]
+  public function prev_header_on_last_page() {
+    $response= newinstance(Response::class, [], [
+      '__construct' => function() { /* Shadow parent */ },
+      'header'      => function($name, $value) use(&$headers) { $headers[$name]= $value; }
+    ]);
+
+    $headers= [];
+    $this->fixture->paginate($this->newRequest('?page=2'), $response, true);
+    $this->assertEquals(
+      ['Link' => new LinkHeader(['prev' => 'http://localhost/?page=1'])],
+      $headers
+    );
+  }
+}

--- a/src/test/php/web/rest/unittest/paging/PaginationTest.class.php
+++ b/src/test/php/web/rest/unittest/paging/PaginationTest.class.php
@@ -1,0 +1,127 @@
+<?php namespace web\rest\unittest\paging;
+
+use web\rest\Response;
+use web\rest\paging\Pagination;
+use web\rest\paging\PageParameters;
+use web\Request;
+use web\io\TestInput;
+
+class PaginationTest extends \unittest\TestCase {
+  const SIZE = 50;
+
+  /**
+   * Creates a new request instance
+   *
+   * @param  string $queryString
+   * @return web.rest.paging.Pagination
+   */
+  protected function newFixture($queryString= '') {
+    return new Pagination(
+      new Request(new TestInput('GET', '/'.$queryString)),
+      new PageParameters('page', 'per_page'),
+      self::SIZE
+    );
+  }
+
+  #[@test]
+  public function can_create() {
+    $this->newFixture();
+  }
+
+  #[@test, @values([
+  #  ['', 0],
+  #  ['?page=1', 0],
+  #  ['?page=2', self::SIZE],
+  #  ['?page=1&per_page=10', 0],
+  #  ['?page=2&per_page=10', 10]
+  #])]
+  public function start($queryString, $offset) {
+    $this->assertEquals($offset, $this->newFixture($queryString)->start(0));
+  }
+
+  #[@test, @values([
+  #  ['', self::SIZE],
+  #  ['?page=1', self::SIZE],
+  #  ['?page=1&per_page=10', 10],
+  #  ['?page=2&per_page=10', 20]
+  #])]
+  public function end($queryString, $offset) {
+    $this->assertEquals($offset, $this->newFixture($queryString)->end(0));
+  }
+
+  #[@test]
+  public function limit_defaults_to_size() {
+    $this->assertEquals(self::SIZE, $this->newFixture()->limit());
+  }
+
+  #[@test]
+  public function limit_explicitely_given() {
+    $this->assertEquals(10, $this->newFixture('?per_page=10')->limit());
+  }
+
+  #[@test]
+  public function paginate_on_empty() {
+    $this->newFixture()->paginate([], newinstance(Response::class, [], [
+      '__construct' => function() { /* Shadow parent */ },
+      'entity'      => function($value) use(&$entity) { $entity= $value; return $this; }
+    ]));
+    $this->assertEquals([], $entity);
+  }
+
+  #[@test, @values([
+  #  [[1, 2, 3]],
+  #  [new \ArrayIterator([1, 2, 3])],
+  #  [new \ArrayObject([1, 2, 3])]
+  #])]
+  public function paginate_on($value) {
+    $this->newFixture()->paginate($value, newinstance(Response::class, [], [
+      '__construct' => function() { /* Shadow parent */ },
+      'entity'      => function($value) use(&$entity) { $entity= $value; return $this; }
+    ]));
+    $this->assertEquals([1, 2, 3], $entity);
+  }
+
+  #[@test]
+  public function paginate_on_generator() {
+    $generator= function() { yield 1; yield 2; yield 3; };
+    $this->newFixture()->paginate($generator(), newinstance(Response::class, [], [
+      '__construct' => function() { /* Shadow parent */ },
+      'entity'      => function($value) use(&$entity) { $entity= $value; return $this; }
+    ]));
+    $this->assertEquals([1, 2, 3], $entity);
+  }
+
+  #[@test, @values([1, 2, self::SIZE])]
+  public function paginate($size) {
+    $elements= array_fill(0, $size, 'element');
+    $this->newFixture()->paginate($elements, newinstance(Response::class, [], [
+      '__construct' => function() { /* Shadow parent */ },
+      'entity'      => function($value) use(&$entity) { $entity= $value; return $this; }
+    ]));
+    $this->assertEquals($elements, $entity);
+  }
+
+  #[@test, @values([1, 2, self::SIZE])]
+  public function paginate_removes_excess_elements_from_array($by) {
+    $elements= array_fill(0, self::SIZE + $by, 'element');
+    $this->newFixture()->paginate($elements, newinstance(Response::class, [], [
+      '__construct' => function() { /* Shadow parent */ },
+      'entity'      => function($value) use(&$entity) { $entity= $value; return $this; }
+    ]));
+    $this->assertEquals(array_fill(0, self::SIZE, 'element'), $entity);
+  }
+
+  #[@test, @values([1, 2, self::SIZE])]
+  public function paginate_removes_excess_elements_from_generator($by) {
+    $generator= function() use($by) {
+      for ($i= 0; $i < self::SIZE + $by; $i++) {
+        yield 'element';
+      }
+    };
+    $this->newFixture()->paginate($generator(), newinstance(Response::class, [], [
+      '__construct' => function() { /* Shadow parent */ },
+      'entity'      => function($value) use(&$entity) { $entity= $value; return $this; }
+    ]));
+    $this->assertEquals(array_fill(0, self::SIZE, 'element'), $entity);
+  }
+}


### PR DESCRIPTION
This pull request adds a pagination mechanism. It is based on https://github.com/xp-framework/rest/pull/7

## Usage

Put this in your base class or a trait:

```php
use web\rest\paging\{Paging, PageParameters};

protected static function paging(): Paging {
  return new Paging(50, [new PageParameters('page', 'per_page')]);
}
```

Now in the API handler, do the following:

```php
#[@get('/'), @$request: request]
public function all($request) {
  $pagination= self::paging()->on($request);
  return $pagination->paginate($this->conn->query(
    'select id, value from url limit %d, %d',
    $pagination->start(),
    $pagination->limit() + 1
  ));
}
```

Note that we select one more element than necessary in order to detect whether the last page consists of exactly the limit's amount of elements and is in fact the last page or if there is a next page. The pagination mechanism will not return more than the limit's amount in any case though.