### PR TITLE
Two Bugfixes in Marshalling

### DIFF
--- a/src/main/php/web/rest/Marshalling.class.php
+++ b/src/main/php/web/rest/Marshalling.class.php
@@ -50,7 +50,7 @@ class Marshalling {
         return new Date($value);
       } else if ($type->isAssignableFrom(Money::class)) {
         return new Money($value['amount'], Currency::getInstance($value['currency']));
-      } else if (1 === $type->getConstructor()->numParameters()) {
+      } else if ($type->hasConstructor() && 1 === $type->getConstructor()->numParameters()) {
         return $type->newInstance($value);
       }
 
@@ -61,6 +61,8 @@ class Marshalling {
         if ($m & MODIFIER_STATIC) continue;
 
         $n= $field->getName();
+        if (!isset($value[$n])) continue;
+
         if ($m & MODIFIER_PUBLIC) {
           $field->set($r, $this->unmarshal($value[$n], $field->getType()));
         } else if ($type->hasMethod($set= 'set'.ucfirst($n))) {

--- a/src/test/php/web/rest/unittest/MarshallingTest.class.php
+++ b/src/test/php/web/rest/unittest/MarshallingTest.class.php
@@ -170,4 +170,20 @@ class MarshallingTest extends TestCase {
       iterator_to_array((new Marshalling())->unmarshal(['one' => 1, 'two' => 2], Type::$ITERABLE))
     );
   }
+
+  #[@test]
+  public function unmarshal_object_noconstructor_regression() {
+    $this->assertEquals(
+      (new PersonWithoutConstructor())->setId(6100)->setName('Test'),
+      (new Marshalling())->unmarshal(['id' => 6100, 'name' => 'Test'], Type::forName(PersonWithoutConstructor::class))
+    );
+  }
+
+  #[@test]
+  public function unmarshal_object_less_arguments_regression() {
+    $this->assertEquals(
+      (new PersonWithoutConstructor())->setId(6100),
+      (new Marshalling())->unmarshal(['id' => 6100], Type::forName(PersonWithoutConstructor::class))
+    );
+  }
 }

--- a/src/test/php/web/rest/unittest/PersonWithoutConstructor.class.php
+++ b/src/test/php/web/rest/unittest/PersonWithoutConstructor.class.php
@@ -1,0 +1,29 @@
+<?php namespace web\rest\unittest;
+
+class PersonWithoutConstructor {
+
+  /** @var int */
+  public $id;
+
+  /** @var string */
+  public $name;
+
+  /**
+   * @param int $id
+   * @return PersonWithoutConstructor
+   */
+  public function setId($id) {
+    $this->id= $id;
+    return $this;
+  }
+
+  /**
+   * @param string $name
+   * @return PersonWithoutConstructor
+   */
+  public function setName($name) {
+    $this->name= $name;
+    return $this;
+  }
+
+}


### PR DESCRIPTION
I fixed two bugs in Marshalling:

 * If the target object has no constructor ```$type->getConstructor()->numParameters()``` will fail.
 * If an object has a member for which there is no data set, marshalling will fail with an "undefined index" exception.