### PR TITLE
Intercept invocations

### DIFF
--- a/src/main/php/web/rest/Delegate.class.php
+++ b/src/main/php/web/rest/Delegate.class.php
@@ -69,18 +69,25 @@ class Delegate {
    * @param  lang.reflect.Parameter $param
    * @param  string $name
    * @param  string $source
+   * @return void
    */
   private function param($param, $name, $source) {
     if ($param->isOptional()) {
       $default= $param->getDefaultValue();
       $read= function($req, $format) use($source, $name, $default) {
         $f= self::$SOURCES[$source];
-        return null === ($value= $f($req, $format, $name)) ? $default : $value;
+        if (null === ($value= $f($req, $format, $name))) {
+          return $default;
+        }
+        return $value;
       };
     } else {
       $read= function($req, $format) use($source, $name) {
         $f= self::$SOURCES[$source];
-        return $f($req, $format, $name);
+        if (null === ($value= $f($req, $format, $name))) {
+          throw new IllegalArgumentException('Missing argument '.$name);
+        }
+        return $value;
       };
     }
     $this->params[$name]= ['type' => $param->getType(), 'read' => $read];

--- a/src/main/php/web/rest/Delegate.class.php
+++ b/src/main/php/web/rest/Delegate.class.php
@@ -99,7 +99,7 @@ class Delegate {
   /** @return [:var] */
   public function annotations() { return $this->method->getAnnotations(); }
 
-  /** @return [:function(web.Request, web.rest.format.EntityFormat): var] */
+  /** @return [:var] */
   public function params() { return $this->params; }
 
   /**

--- a/src/main/php/web/rest/Delegate.class.php
+++ b/src/main/php/web/rest/Delegate.class.php
@@ -96,6 +96,9 @@ class Delegate {
   /** @return string */
   public function name() { return nameof($this->instance).'::'.$this->method->getName(); }
 
+  /** @return [:var] */
+  public function annotations() { return $this->method->getAnnotations(); }
+
   /** @return [:function(web.Request, web.rest.format.EntityFormat): var] */
   public function params() { return $this->params; }
 

--- a/src/main/php/web/rest/Interceptor.class.php
+++ b/src/main/php/web/rest/Interceptor.class.php
@@ -1,0 +1,13 @@
+<?php namespace web\rest;
+
+interface Interceptor {
+
+  /**
+   * Intercept an invocation
+   *
+   * @param  web.rest.Invocation $invocation
+   * @param  var[] $args
+   * @return var
+   */
+  public function intercept($invocation, $args);
+}

--- a/src/main/php/web/rest/Invocation.class.php
+++ b/src/main/php/web/rest/Invocation.class.php
@@ -1,16 +1,23 @@
 <?php namespace web\rest;
 
 class Invocation {
-  private $interceptors, $target;
+  private $interceptors= [];
+  private $target;
 
   /**
    * Creates a new invocation
    *
-   * @param  (function(web.rest.Invocation, var[]): var)[] $interceptors
+   * @param  (web.rest.Interceptor|function(web.rest.Invocation, var[]): var)[] $interceptors
    * @param  web.rest.Delegate $target
    */
   public function __construct($interceptors, $target) {
-    $this->interceptors= $interceptors;
+    foreach ($interceptors as $interceptor) {
+      if ($interceptor instanceof Interceptor) {
+        $this->interceptors[]= [$interceptor, 'intercept'];
+      } else {
+        $this->interceptors[]= $interceptor;
+      }
+    }
     $this->interceptors[]= function($self, $args) { return $this->target->invoke($args); };
     $this->target= $target;
   }

--- a/src/main/php/web/rest/Invocation.class.php
+++ b/src/main/php/web/rest/Invocation.class.php
@@ -1,0 +1,32 @@
+<?php namespace web\rest;
+
+class Invocation {
+  private $interceptors, $target;
+
+  /**
+   * Creates a new invocation
+   *
+   * @param  (function(web.rest.Invocation, var[]): var)[] $interceptors
+   * @param  web.rest.Delegate $target
+   */
+  public function __construct($interceptors, $target) {
+    $this->interceptors= $interceptors;
+    $this->interceptors[]= function($self, $args) { return $this->target->invoke($args); };
+    $this->target= $target;
+  }
+
+  /** @return web.rest.Delegate */
+  public function target() { return $this->target; }
+
+  /**
+   * Proceed with the invocation
+   *
+   * @param  var[] $args
+   * @return var
+   * @throws lang.Throwable
+   */
+  public function proceed($args) {
+    $i= array_shift($this->interceptors);
+    return $i($this, $args);
+  }
+}

--- a/src/main/php/web/rest/RestApi.class.php
+++ b/src/main/php/web/rest/RestApi.class.php
@@ -62,7 +62,7 @@ class RestApi implements Handler {
   /**
    * Intercept invocations using a given handler
    *
-   * @param  function(web.rest.Delegate, var[]): var $interceptor
+   * @param  web.rest.Interceptor|function(web.rest.Invocation, var[]): var $interceptor
    * @return self
    */
   public function intercepting($interceptor) {

--- a/src/main/php/web/rest/RestApi.class.php
+++ b/src/main/php/web/rest/RestApi.class.php
@@ -108,10 +108,8 @@ class RestApi implements Handler {
           foreach ($delegate->params() as $name => $definition) {
             if (isset($matches[$name])) {
               $args[]= $this->marshalling->unmarshal($matches[$name], $definition['type']);
-            } else if (null !== ($arg= $definition['read']($req, $format))) {
-              $args[]= $this->marshalling->unmarshal($arg, $definition['type']);
             } else {
-              throw new IllegalArgumentException('Missing argument '.$name);
+              $args[]= $this->marshalling->unmarshal($definition['read']($req, $format), $definition['type']);
             }
           }
         } catch (IllegalArgumentException $e) {

--- a/src/main/php/web/rest/RestApi.class.php
+++ b/src/main/php/web/rest/RestApi.class.php
@@ -49,7 +49,13 @@ class RestApi implements Handler {
     return $this;
   }
 
-  public function invoking($invocations) {
+  /**
+   * Intercept invocations using a given handler
+   *
+   * @param  function(web.rest.Delegate, var[]): var $invocations
+   * @return self
+   */
+  public function intercepting($invocations) {
     $this->invocations= $invocations;
     return $this;
   }

--- a/src/main/php/web/rest/RestApi.class.php
+++ b/src/main/php/web/rest/RestApi.class.php
@@ -10,6 +10,8 @@ use lang\IllegalArgumentException;
 use lang\Throwable;
 
 class RestApi implements Handler {
+  private static $METHODS= ['get', 'head', 'post', 'put', 'patch', 'delete', 'options'];
+
   private $formats= [];
   private $delegates= [];
   private $marshalling, $invocations;
@@ -23,11 +25,13 @@ class RestApi implements Handler {
   public function __construct($instance, $base= '/') {
     foreach (typeof($instance)->getMethods() as $method) {
       foreach ($method->getAnnotations() as $verb => $segment) {
-        $pattern= $segment
-          ? preg_replace(['/\{([^:}]+):([^}]+)\}/', '/\{([^}]+)\}/'], ['(?<$1>$2)', '(?<$1>[^/]+)'], $segment)
-          : '.+'
-        ;
-        $this->delegates['#^'.$verb.':'.rtrim($base, '/').$pattern.'$#']= new Delegate($instance, $method);
+        if (in_array($verb, self::$METHODS)) {
+          $pattern= $segment
+            ? preg_replace(['/\{([^:}]+):([^}]+)\}/', '/\{([^}]+)\}/'], ['(?<$1>$2)', '(?<$1>[^/]+)'], $segment)
+            : '.+'
+          ;
+          $this->delegates['#^'.$verb.':'.rtrim($base, '/').$pattern.'$#']= new Delegate($instance, $method);
+        }
       }
     }
 

--- a/src/main/php/web/rest/RestApi.class.php
+++ b/src/main/php/web/rest/RestApi.class.php
@@ -10,7 +10,15 @@ use lang\IllegalArgumentException;
 use lang\Throwable;
 
 class RestApi implements Handler {
-  private static $METHODS= ['get', 'head', 'post', 'put', 'patch', 'delete', 'options'];
+  private static $METHODS= [
+    'get'     => null,
+    'head'    => null,
+    'post'    => null,
+    'put'     => null,
+    'patch'   => null,
+    'delete'  => null,
+    'options' => null
+  ];
 
   private $formats= [];
   private $delegates= [];
@@ -24,14 +32,12 @@ class RestApi implements Handler {
    */
   public function __construct($instance, $base= '/') {
     foreach (typeof($instance)->getMethods() as $method) {
-      foreach ($method->getAnnotations() as $verb => $segment) {
-        if (in_array($verb, self::$METHODS)) {
-          $pattern= $segment
-            ? preg_replace(['/\{([^:}]+):([^}]+)\}/', '/\{([^}]+)\}/'], ['(?<$1>$2)', '(?<$1>[^/]+)'], $segment)
-            : '.+'
-          ;
-          $this->delegates['#^'.$verb.':'.rtrim($base, '/').$pattern.'$#']= new Delegate($instance, $method);
-        }
+      foreach (array_intersect_key($method->getAnnotations(), self::$METHODS) as $verb => $segment) {
+        $pattern= $segment
+          ? preg_replace(['/\{([^:}]+):([^}]+)\}/', '/\{([^}]+)\}/'], ['(?<$1>$2)', '(?<$1>[^/]+)'], $segment)
+          : '.+'
+        ;
+        $this->delegates['#^'.$verb.':'.rtrim($base, '/').$pattern.'$#']= new Delegate($instance, $method);
       }
     }
 

--- a/src/test/php/web/rest/unittest/InvocationsTest.class.php
+++ b/src/test/php/web/rest/unittest/InvocationsTest.class.php
@@ -49,9 +49,9 @@ class InvocationsTest extends TestCase {
 
   #[@test]
   public function intercepting_with_callable() {
-    $invocations= function($delegate, $args) use(&$invoked) {
-      $invoked= [$delegate->name(), $args];
-      return $delegate->invoke($args);
+    $invocations= function($invocation, $args) use(&$invoked) {
+      $invoked= [$invocation->target()->name(), $args];
+      return $invocation->proceed($args);
     };
 
     $this->run((new RestApi(new Users()))->intercepting($invocations), 'GET', '/users/1549');
@@ -60,9 +60,9 @@ class InvocationsTest extends TestCase {
 
   #[@test]
   public function intercepting_catching_exceptions() {
-    $invocations= function($delegate, $args) use(&$caught) {
+    $invocations= function($invocation, $args) use(&$caught) {
       try {
-        return $delegate->invoke($args);
+        return $invocation->proceed($args);
       } catch (ElementNotFoundException $e) {
         $caught= [nameof($e), $e->getMessage()];
         return RestResponse::error(404, $e);
@@ -75,9 +75,9 @@ class InvocationsTest extends TestCase {
 
   #[@test]
   public function intercepting_can_access_annotations() {
-    $invocations= function($delegate, $args) use(&$cached) {
-      $cached= $delegate->annotations()['cached'];
-      return $delegate->invoke($args);
+    $invocations= function($invocation, $args) use(&$cached) {
+      $cached= $invocation->target()->annotations()['cached'];
+      return $invocation->proceed($args);
     };
 
     $this->run((new RestApi(new Users()))->intercepting($invocations), 'GET', '/users/1549/avatar');

--- a/src/test/php/web/rest/unittest/InvocationsTest.class.php
+++ b/src/test/php/web/rest/unittest/InvocationsTest.class.php
@@ -2,6 +2,7 @@
 
 use unittest\TestCase;
 use web\rest\RestApi;
+use web\rest\Interceptor;
 use web\Request;
 use web\Response;
 use web\io\TestInput;
@@ -46,6 +47,19 @@ class InvocationsTest extends TestCase {
 
     $api->handle($req, $res);
     return $res;
+  }
+
+  #[@test]
+  public function intercepting() {
+    $invocations= newinstance(Interceptor::class, [], [
+      'intercept' => function($invocation, $args) use(&$invoked) {
+        $invoked= [$invocation->target()->name(), $args];
+        return $invocation->proceed($args);
+      }
+    ]);
+
+    $this->run((new RestApi(new Users()))->intercepting($invocations), 'GET', '/users/1549');
+    $this->assertEquals(['web.rest.unittest.Users::findUser', ['1549']], $invoked);
   }
 
   #[@test]

--- a/src/test/php/web/rest/unittest/InvocationsTest.class.php
+++ b/src/test/php/web/rest/unittest/InvocationsTest.class.php
@@ -72,4 +72,14 @@ class InvocationsTest extends TestCase {
     $this->run((new RestApi(new Users()))->intercepting($invocations), 'GET', '/users/0');
     $this->assertEquals(['lang.ElementNotFoundException', 'No such user #0'], $caught);
   }
-}
+
+  #[@test]
+  public function intercepting_can_access_annotations() {
+    $invocations= function($delegate, $args) use(&$cached) {
+      $cached= $delegate->annotations()['cached'];
+      return $delegate->invoke($args);
+    };
+
+    $this->run((new RestApi(new Users()))->intercepting($invocations), 'GET', '/users/1549/avatar');
+    $this->assertEquals(['ttl' => 3600], $cached);
+  }}

--- a/src/test/php/web/rest/unittest/InvocationsTest.class.php
+++ b/src/test/php/web/rest/unittest/InvocationsTest.class.php
@@ -1,0 +1,58 @@
+<?php namespace web\rest\unittest;
+
+use unittest\TestCase;
+use web\rest\RestApi;
+use web\Request;
+use web\Response;
+use web\io\TestInput;
+use web\io\TestOutput;
+
+class InvocationsTest extends TestCase {
+
+  /**
+   * Assertion helper - tests HTTP payload. Assumes chunked transfer-encoding.
+   *
+   * @param  int $status
+   * @param  string $mime
+   * @param  string $body
+   * @param  web.Response $res
+   * @throws unittest.AssertionFailedError
+   * @return void
+   */
+  private function assertPayload($status, $mime, $body, $res) {
+    $bytes= $res->output()->bytes();
+    $this->assertEquals(
+      ['status' => $status, 'mime' => $mime, 'body' => dechex(strlen($body))."\r\n".$body."\r\n0\r\n\r\n"],
+      ['status' => $res->status(), 'mime' => $res->headers()['Content-Type'], 'body' => substr($bytes, strpos($bytes, "\r\n\r\n") + 4)]
+    );
+  }
+
+  /**
+   * Runs the handler
+   *
+   * @param  web.rest.RestApi $api
+   * @param  string $method
+   * @param  string $uri
+   * @param  [:string] $headers
+   * @param  string $body
+   * @return web.Response
+   */
+  private function run($api, $method, $uri, $headers= [], $body= null) {
+    $req= new Request(new TestInput($method, $uri, $headers, $body));
+    $res= new Response(new TestOutput());
+
+    $api->handle($req, $res);
+    return $res;
+  }
+
+  #[@test]
+  public function invoking_callable() {
+    $invocation= function($delegate, $args) use(&$invoked) {
+      $invoked= [$delegate->name(), $args];
+      return $delegate->invoke($args);
+    };
+
+    $this->run((new RestApi(new Users()))->invoking($invocation), 'GET', '/users/1549');
+    $this->assertEquals(['web.rest.unittest.Users::findUser', ['1549']], $invoked);
+  }
+}

--- a/src/test/php/web/rest/unittest/InvocationsTest.class.php
+++ b/src/test/php/web/rest/unittest/InvocationsTest.class.php
@@ -47,12 +47,12 @@ class InvocationsTest extends TestCase {
 
   #[@test]
   public function invoking_callable() {
-    $invocation= function($delegate, $args) use(&$invoked) {
+    $invocations= function($delegate, $args) use(&$invoked) {
       $invoked= [$delegate->name(), $args];
       return $delegate->invoke($args);
     };
 
-    $this->run((new RestApi(new Users()))->invoking($invocation), 'GET', '/users/1549');
+    $this->run((new RestApi(new Users()))->intercepting($invocations), 'GET', '/users/1549');
     $this->assertEquals(['web.rest.unittest.Users::findUser', ['1549']], $invoked);
   }
 }

--- a/src/test/php/web/rest/unittest/Users.class.php
+++ b/src/test/php/web/rest/unittest/Users.class.php
@@ -36,7 +36,7 @@ class Users {
     return Response::created('/users/'.$id)->entity($new);
   }
 
-  #[@get('/users/{id}/avatar')]
+  #[@get('/users/{id}/avatar'), @cached(ttl= 3600)]
   public function userAvatar($id) {
     if (!isset($this->users[$id])) {
       return Response::notFound('No such user #'.$id);


### PR DESCRIPTION
This pull request adds the ability to pass an invocation interceptor to REST API handlers. The function called is modelled after AOP "AroundInvoke" interceptors.

## Example

```php
use web\rest\{RestApi, Response};

$api= (new RestApi(new Users()))->intercepting(function($invocation, $args) {
  try {
    return $invocation->proceed($args);
  } catch (ElementNotFoundException $e) {
    return Response::error(404, $e);
  }
});
```

## Usecases

* Logging
* Performance profiling
* Caching
* Input validation
* Exception handling