### PR TITLE
Accept instances or delegates in RestApi constructor

### DIFF
--- a/src/main/php/web/rest/ClassesIn.class.php
+++ b/src/main/php/web/rest/ClassesIn.class.php
@@ -1,0 +1,25 @@
+<?php namespace web\rest;
+
+use lang\reflect\Package;
+
+/**
+ * Creates routing based on classes in a given package
+ */
+class ClassesIn extends Delegates {
+
+  /**
+   * Creates this delegates instance
+   *
+   * @param  lang.reflect.Package|string $package
+   * @param  function(lang.XPClass): object $new Optional function to create instances
+   */
+  public function __construct($package, $new= null) {
+    $p= $package instanceof Package ? $package : Package::forName($package);
+    foreach ($p->getClasses() as $class) {
+      if ($class->reflect()->isInstantiable()) {
+        $this->with($new ? $new($class) : $class->newInstance());
+      }
+    }
+    uksort($this->patterns, function($a, $b) { return strlen($b) - strlen($a); });
+  }
+}

--- a/src/main/php/web/rest/Delegates.class.php
+++ b/src/main/php/web/rest/Delegates.class.php
@@ -1,0 +1,58 @@
+<?php namespace web\rest;
+
+use lang\IllegalArgumentException;
+
+/**
+ * Matches request and routes to correct delegate
+ */
+class Delegates {
+  private static $METHODS= [
+    'get'     => null,
+    'head'    => null,
+    'post'    => null,
+    'put'     => null,
+    'patch'   => null,
+    'delete'  => null,
+    'options' => null
+  ];
+  public $patterns= [];
+
+  /**
+   * Routes to instance methods based on annotations
+   *
+   * @param  object $instance
+   * @return self
+   * @throws lang.IllegalArgumentException
+   */
+  public function with($instance) {
+    if (!is_object($instance)) {
+      throw new IllegalArgumentException('Expected an object, have '.typeof($instance));
+    }
+
+    foreach (typeof($instance)->getMethods() as $method) {
+      foreach (array_intersect_key($method->getAnnotations(), self::$METHODS) as $verb => $segment) {
+        $pattern= $segment
+          ? preg_replace(['/\{([^:}]+):([^}]+)\}/', '/\{([^}]+)\}/'], ['(?<$1>$2)', '(?<$1>[^/]+)'], $segment)
+          : '.+'
+        ;
+        $this->patterns['#^'.$verb.$pattern.'$#']= new Delegate($instance, $method);
+      }
+    }
+    return $this;
+  }
+
+  /**
+   * Returns target for a given HTTP verb and path
+   *
+   * @param  string $verb
+   * @param  string $path
+   * @return web.frontend.Delegate or NULL
+   */
+  public function target($verb, $path) {
+    $match= $verb.$path;
+    foreach ($this->patterns as $pattern => $delegate) {
+      if (preg_match($pattern, $match, $matches)) return [$delegate, $matches];
+    }
+    return null;
+  }
+}

--- a/src/main/php/web/rest/MethodsIn.class.php
+++ b/src/main/php/web/rest/MethodsIn.class.php
@@ -1,0 +1,13 @@
+<?php namespace web\rest;
+
+/**
+ * Creates routing based on a given instance
+ */
+class MethodsIn extends Delegates {
+
+  /** @param object $instance */
+  public function __construct($instance) {
+    $this->with($instance);
+    uksort($this->patterns, function($a, $b) { return strlen($b) - strlen($a); });
+  }
+}

--- a/src/main/php/web/rest/RestApi.class.php
+++ b/src/main/php/web/rest/RestApi.class.php
@@ -10,10 +10,8 @@ use web\rest\format\OctetStream;
 use web\routing\CannotRoute;
 
 class RestApi implements Handler {
-  private $formats= [];
-  private $delegates= [];
+  private $delegates, $base, $marshalling, $formats;
   private $invocations= [];
-  private $marshalling;
 
   /**
    * Creates a new REST API instance for a given handler
@@ -24,9 +22,12 @@ class RestApi implements Handler {
   public function __construct($arg, $base= '/') {
     $this->delegates= $arg instanceof Delegates ? $arg : new MethodsIn($arg);
     $this->base= rtrim($base, '/');
-    $this->formats['#(application|text)/.*json#']= new Json();
-    $this->formats['#application/octet-stream#']= new OctetStream();
     $this->marshalling= new Marshalling();
+
+    $this->formats= [
+      '#(application|text)/.*json#' => new Json(),
+      '#application/octet-stream#'  => new OctetStream()
+    ];
   }
 
   /**

--- a/src/main/php/web/rest/RestApi.class.php
+++ b/src/main/php/web/rest/RestApi.class.php
@@ -23,7 +23,6 @@ class RestApi implements Handler {
     $this->delegates= $arg instanceof Delegates ? $arg : new MethodsIn($arg);
     $this->base= rtrim($base, '/');
     $this->marshalling= new Marshalling();
-
     $this->formats= [
       '#(application|text)/.*json#' => new Json(),
       '#application/octet-stream#'  => new OctetStream()
@@ -98,8 +97,8 @@ class RestApi implements Handler {
     if (null === ($target= $this->delegates->target($verb, $path))) {
       throw new CannotRoute($req);
     }
-    list($delegate, $matches)= $target;
 
+    list($delegate, $matches)= $target;
     try {
       $args= [];
       foreach ($delegate->params() as $name => $definition) {

--- a/src/test/php/web/rest/unittest/InvocationsTest.class.php
+++ b/src/test/php/web/rest/unittest/InvocationsTest.class.php
@@ -5,6 +5,7 @@ use lang\IllegalStateException;
 use web\rest\Interceptor;
 use web\rest\Response;
 use web\rest\RestApi;
+use web\rest\unittest\api\Users;
 
 class InvocationsTest extends RunTest {
 
@@ -18,7 +19,7 @@ class InvocationsTest extends RunTest {
     ]);
 
     $this->run((new RestApi(new Users()))->intercepting($invocations), 'GET', '/users/1549');
-    $this->assertEquals(['web.rest.unittest.Users::findUser', ['1549']], $invoked);
+    $this->assertEquals(['web.rest.unittest.api.Users::findUser', ['1549']], $invoked);
   }
 
   #[@test]
@@ -29,7 +30,7 @@ class InvocationsTest extends RunTest {
     };
 
     $this->run((new RestApi(new Users()))->intercepting($invocations), 'GET', '/users/1549');
-    $this->assertEquals(['web.rest.unittest.Users::findUser', ['1549']], $invoked);
+    $this->assertEquals(['web.rest.unittest.api.Users::findUser', ['1549']], $invoked);
   }
 
   #[@test]

--- a/src/test/php/web/rest/unittest/MarshallingTest.class.php
+++ b/src/test/php/web/rest/unittest/MarshallingTest.class.php
@@ -1,11 +1,11 @@
 <?php namespace web\rest\unittest;
 
+use lang\Type;
 use unittest\TestCase;
-use web\rest\Marshalling;
+use util\Currency;
 use util\Date;
 use util\Money;
-use util\Currency;
-use lang\Type;
+use web\rest\Marshalling;
 
 class MarshallingTest extends TestCase {
 

--- a/src/test/php/web/rest/unittest/RestApiTest.class.php
+++ b/src/test/php/web/rest/unittest/RestApiTest.class.php
@@ -3,6 +3,7 @@
 use web\rest\ClassesIn;
 use web\rest\MethodsIn;
 use web\rest\RestApi;
+use web\rest\unittest\api\Monitoring;
 use web\rest\unittest\api\Users;
 
 class RestApiTest extends RunTest {

--- a/src/test/php/web/rest/unittest/RestApiTest.class.php
+++ b/src/test/php/web/rest/unittest/RestApiTest.class.php
@@ -1,12 +1,25 @@
 <?php namespace web\rest\unittest;
 
+use web\rest\ClassesIn;
+use web\rest\MethodsIn;
 use web\rest\RestApi;
+use web\rest\unittest\api\Users;
 
 class RestApiTest extends RunTest {
 
   #[@test]
   public function can_create() {
     new RestApi(new Users());
+  }
+
+  #[@test]
+  public function can_create_with_methods_delegates() {
+    new RestApi(new MethodsIn(new Users()));
+  }
+
+  #[@test]
+  public function can_create_with_classes_delegates() {
+    new RestApi(new ClassesIn('web.rest.unittest.api'));
   }
 
   #[@test]

--- a/src/test/php/web/rest/unittest/api/Monitoring.class.php
+++ b/src/test/php/web/rest/unittest/api/Monitoring.class.php
@@ -1,10 +1,11 @@
-<?php namespace web\rest\unittest;
+<?php namespace web\rest\unittest\api;
 
-use web\Request;
-use web\rest\Response;
+use util\Currency;
 use util\Date;
 use util\Money;
-use util\Currency;
+use web\Request;
+use web\rest\Response;
+use web\rest\unittest\Person;
 
 class Monitoring {
   private $startup, $responsible;

--- a/src/test/php/web/rest/unittest/api/Users.class.php
+++ b/src/test/php/web/rest/unittest/api/Users.class.php
@@ -1,4 +1,4 @@
-<?php namespace web\rest\unittest;
+<?php namespace web\rest\unittest\api;
 
 use io\streams\InputStream;
 use io\streams\MemoryInputStream;


### PR DESCRIPTION
Adds shorthand alternative to manually entering all routes:

```php
use web\Application;
use web\rest\{RestApi, ClassesIn};
use com\example\rest\api\{Users, Posts};

class Service extends Application {
  public function routes() {
    return [
      // Route /users to Users class, /posts to Posts, etcetera...
      '/api/users' => new RestApi(new Users()),
      '/api/posts' => new RestApi(new Posts()),

      // ...or just do it with one call
      '/api' => new RestApi(new ClassesIn('com.example.rest.api'))
    ];
  }
}
```

To integrate well with `xp-forge/inject`, the `ClassesIn` constructor accepts an optional creation function. Usage example:

```php
$inject= new Injector(...);

$api= new RestApi(new ClassesIn('com.example.rest.api', [$inject, 'get']));
```