### PR TITLE
Use ResourcesIn instead of ClassesIn

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,20 @@ Example
 ```php
 use web\rest\Response;
 
+#[@resource('/users')]
 class Users {
 
-  #[@get('/users'), @$max: param]
+  #[@get('/'), @$max: param]
   public function listUsers($max= 10) {
     // ...
   }
 
-  #[@get('/users/{id}')]
+  #[@get('/{id}')]
   public function getUser($id) {
     // ...
   }
 
-  #[@post('/users'), @$user: entity]
+  #[@post('/'), @$user: entity]
   public function createUser($user) {
     // ...
     return Response::created('/users/'.$id)->entity($created);

--- a/src/main/php/web/rest/ClassesIn.class.php
+++ b/src/main/php/web/rest/ClassesIn.class.php
@@ -4,6 +4,8 @@ use lang\reflect\Package;
 
 /**
  * Creates routing based on classes in a given package
+ *
+ * @deprecated Use ResourcesIn instead!
  */
 class ClassesIn extends Delegates {
 

--- a/src/main/php/web/rest/MethodsIn.class.php
+++ b/src/main/php/web/rest/MethodsIn.class.php
@@ -7,7 +7,8 @@ class MethodsIn extends Delegates {
 
   /** @param object $instance */
   public function __construct($instance) {
-    $this->with($instance);
+    $class= typeof($instance);
+    $this->with($instance, $class->hasAnnotation('resource') ? $class->getAnnotation('resource') : '/');
     uksort($this->patterns, function($a, $b) { return strlen($b) - strlen($a); });
   }
 }

--- a/src/main/php/web/rest/ResourcesIn.class.php
+++ b/src/main/php/web/rest/ResourcesIn.class.php
@@ -18,8 +18,8 @@ class ResourcesIn extends Delegates {
   public function __construct($package, $new= null) {
     $p= $package instanceof Package ? $package : Package::forName($package);
     foreach ($p->getClasses() as $class) {
-      if ($class->reflect()->isInstantiable()) {
-        $this->with($new ? $new($class) : $class->newInstance());
+      if ($class->hasAnnotation('resource')) {
+        $this->with($new ? $new($class) : $class->newInstance(), $class->getAnnotation('resource'));
       }
     }
     uksort($this->patterns, function($a, $b) { return strlen($b) - strlen($a); });

--- a/src/main/php/web/rest/ResourcesIn.class.php
+++ b/src/main/php/web/rest/ResourcesIn.class.php
@@ -1,0 +1,27 @@
+<?php namespace web\rest;
+
+use lang\reflect\Package;
+
+/**
+ * Creates routing based on resource classes in a given package
+ *
+ * @test  xp://web.rest.unittest.ResourcesInTest
+ */
+class ResourcesIn extends Delegates {
+
+  /**
+   * Creates this delegates instance
+   *
+   * @param  lang.reflect.Package|string $package
+   * @param  function(lang.XPClass): object $new Optional function to create instances
+   */
+  public function __construct($package, $new= null) {
+    $p= $package instanceof Package ? $package : Package::forName($package);
+    foreach ($p->getClasses() as $class) {
+      if ($class->reflect()->isInstantiable()) {
+        $this->with($new ? $new($class) : $class->newInstance());
+      }
+    }
+    uksort($this->patterns, function($a, $b) { return strlen($b) - strlen($a); });
+  }
+}

--- a/src/test/php/web/rest/unittest/ResourcesInTest.class.php
+++ b/src/test/php/web/rest/unittest/ResourcesInTest.class.php
@@ -25,6 +25,7 @@ class ResourcesInTest extends TestCase {
       $classes[]= $class->getName();
       return $class->newInstance();
     });
+    sort($classes);
     $this->assertEquals(['web.rest.unittest.api.Monitoring', 'web.rest.unittest.api.Users'], $classes);
   }
 }

--- a/src/test/php/web/rest/unittest/ResourcesInTest.class.php
+++ b/src/test/php/web/rest/unittest/ResourcesInTest.class.php
@@ -1,0 +1,30 @@
+<?php namespace web\rest\unittest;
+
+use lang\reflect\Package;
+use unittest\TestCase;
+use web\rest\ResourcesIn;
+
+class ResourcesInTest extends TestCase {
+
+  #[@test]
+  public function using_package_name() {
+    $r= new ResourcesIn('web.rest.unittest.api');
+    $this->assertNotEquals(null, $r->target('get', '/monitoring/status'));
+  }
+
+  #[@test]
+  public function using_package_instance() {
+    $r= new ResourcesIn(Package::forName('web.rest.unittest.api'));
+    $this->assertNotEquals(null, $r->target('get', '/monitoring/status'));
+  }
+
+  #[@test]
+  public function supply_creation_function() {
+    $classes= [];
+    $r= new ResourcesIn('web.rest.unittest.api', function($class) use(&$classes) {
+      $classes[]= $class->getName();
+      return $class->newInstance();
+    });
+    $this->assertEquals(['web.rest.unittest.api.Monitoring', 'web.rest.unittest.api.Users'], $classes);
+  }
+}

--- a/src/test/php/web/rest/unittest/RestApiTest.class.php
+++ b/src/test/php/web/rest/unittest/RestApiTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace web\rest\unittest;
 
 use web\Error;
-use web\rest\ClassesIn;
 use web\rest\MethodsIn;
+use web\rest\ResourcesIn;
 use web\rest\RestApi;
 use web\rest\format\Json;
 use web\rest\unittest\api\Monitoring;
@@ -22,7 +22,7 @@ class RestApiTest extends RunTest {
 
   #[@test]
   public function can_create_with_classes_delegates() {
-    new RestApi(new ClassesIn('web.rest.unittest.api'));
+    new RestApi(new ResourcesIn('web.rest.unittest.api'));
   }
 
   #[@test]
@@ -105,12 +105,12 @@ class RestApiTest extends RunTest {
   #[@test]
   public function objects_are_marshalled() {
     $res= $this->run(new RestApi(new Monitoring()), 'GET', '/monitoring/details');
-    $details= '{'.
+    $details= '{"values":{'.
       '"startup":"2018-06-02T14:12:11+0200",'.
       '"core":"XP9",'.
       '"responsible":{"id":1549,"name":"Timm"},'.
       '"cost":{"amount":"3.5","currency":"EUR"}'.
-    '}';
+    '}}';
     $this->assertPayload(200, 'application/json', $details, $res);
   }
 

--- a/src/test/php/web/rest/unittest/api/Details.class.php
+++ b/src/test/php/web/rest/unittest/api/Details.class.php
@@ -1,0 +1,9 @@
+<?php namespace web\rest\unittest\api;
+
+class Details {
+  private $values;
+
+  public function __construct($values) {
+    $this->values= $values;
+  }
+}

--- a/src/test/php/web/rest/unittest/api/Monitoring.class.php
+++ b/src/test/php/web/rest/unittest/api/Monitoring.class.php
@@ -7,6 +7,7 @@ use web\Request;
 use web\rest\Response;
 use web\rest\unittest\Person;
 
+#[@resource]
 class Monitoring {
   private $startup, $responsible;
 
@@ -28,12 +29,12 @@ class Monitoring {
 
   #[@get('/monitoring/details')]
   public function startup() {
-    return [
+    return new Details([
       'startup'     => $this->startup,
       'core'        => 'XP9',
       'responsible' => $this->responsible,
       'cost'        => new Money(3.50, Currency::$EUR)
-    ];
+    ]);
   }
 
   #[@put('/monitoring/startup'), @$startup: entity]

--- a/src/test/php/web/rest/unittest/api/Users.class.php
+++ b/src/test/php/web/rest/unittest/api/Users.class.php
@@ -5,24 +5,25 @@ use io\streams\MemoryInputStream;
 use lang\ElementNotFoundException;
 use web\rest\Response;
 
+#[@resource('/users')]
 class Users {
   private $users= [
     1549 => ['id' => 1549, 'name' => 'Timm'],
     6100 => ['id' => 6100, 'name' => 'Test'],
   ];
 
-  #[@get('/users')]
+  #[@get('/')]
   public function listUsers() {
     yield 1549 => $this->users[1549];
     yield 6100 => $this->users[6100];
   }
 
-  #[@get('/users/count')]
+  #[@get('/count')]
   public function numUsers() {
     return Response::ok()->entity(sizeof($this->users));
   }
 
-  #[@get('/users/{id:[0-9]+}')]
+  #[@get('/{id:[0-9]+}')]
   public function findUser($id) {
     if (!isset($this->users[$id])) {
       throw new ElementNotFoundException('No such user #'.$id);
@@ -31,17 +32,17 @@ class Users {
     return $this->users[$id];
   }
 
-  #[@post('/users'), @$user: entity]
+  #[@post('/'), @$user: entity]
   public function newUser($user) {
     end($this->users);
     $id= key($this->users) + 1;
     $new= ['id' => $id, 'name' => $user['name']]; 
 
     $this->users[$id]= $new;
-    return Response::created('/users/'.$id)->entity($new);
+    return Response::created('/'.$id)->entity($new);
   }
 
-  #[@get('/users/{id}/avatar'), @cached(ttl= 3600)]
+  #[@get('/{id}/avatar'), @cached(ttl= 3600)]
   public function userAvatar($id) {
     if (!isset($this->users[$id])) {
       return Response::notFound('No such user #'.$id);
@@ -51,7 +52,7 @@ class Users {
     return Response::ok()->type('image/png')->stream(new MemoryInputStream('PNG...'));
   }
 
-  #[@put('/users/{id}/avatar')]
+  #[@put('/{id}/avatar')]
   public function changeUserAvatar($id, InputStream $stream) {
     if (!isset($this->users[$id])) {
       return Response::notFound('No such user #'.$id);


### PR DESCRIPTION
This pull request creates a new `ResourcesIn` class to supersede `ClassesIn`, which is now deprecated. The reason is confusion and a potential naming conflict with the `ClassesIn` class from the [xp-forge/frontend](https://github.com/xp-forge/frontend) library. Also, because the old implementation will simply register any instantiable class as delegate, there's no real way to put DTOs and related code next to the resource classes; instead, this would always need to be in a separate package.

Refactoring code means replacing *ClassesIn* With *ResourcesIn* inside the application **and** adding the `@resource` annotation to all classes.

Resource class:
```php
#[@resource]    // NEW!
class Users {

  #[@get('/api/users'), @$max: param]
  public function listUsers($max= 10) {
    // ...
  }
}
```

Application:
```php
use web\Application;
use web\rest\{RestApi, ResourcesIn};    // ...instead of ClassesIn

class Service extends Application {

  public function routes() {
    return [
      '/api' => new RestApi(new ResourcesIn('com.example.rest.api'))  // ...also rename here
    ];
  }
}
```

See also #5 

/cc @johannes85 