### PR TITLE
Parameter defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,13 @@ Example
 -------
 
 ```php
-use web\rest\{Get, Post, Resource, Response, Param, Entity};
+use web\rest\{Get, Post, Resource, Response};
 
 #[Resource('/users')]
 class Users {
 
   #[Get('/')]
-  public function listUsers(
-    #[Param]
-    $max= 10
-  ) {
+  public function listUsers($max= 10) {
     // ...
   }
 
@@ -32,10 +29,7 @@ class Users {
   }
 
   #[Post('/')]
-  public function createUser(
-    #[Entity]
-    $user
-  ) {
+  public function createUser($user) {
     // ...
     return Response::created('/users/'.$id)->entity($created);
   }
@@ -69,16 +63,18 @@ Then call `curl -i localhost:8080/users/1549`.
 Parameter sources
 -----------------
 
-Method parameters are automatically extracted from URI segments if their name matches the string in the curly braces. For other sources, you will need to supply a method attribute:
+Method parameters are automatically extracted from URI segments if their name matches the path segment in the curly braces. For requests without bodies (GET, HEAD, DELETE, OPTIONS), the value is extracted from request parameters. For requests with bodies (POST, PUT and PATCH), the body is deserialized and passed.
+
+To supply the source explicitely, you can use parameter attributes:
 
 * `#[Param]` will fetch the parameter from the request parameter named "max".
 * `#[Param('maximum')]` will fetch the parameter from the request parameter named "maximum".
 * `#[Value]` will use a request value (which was previously passed e.g. inside a filter via `pass()`) for the parameter
 * `#[Header('Content-Type')]` will use the *Content-Type* header as value for the parameter
 * `#[Entity]` will deserialize the request body and pass its value to the parameter
-* `#[Stream]` will pass an `io.streams.InputStream` instance to stream the request body to the parameter
 * `#[Body]` will pass the request body as a string
-* `#[Request]` will pass the complete request object
+* `#[Stream]` will pass an `io.streams.InputStream` instance to stream the request body to the parameter
+* `#[Request]` will pass the complete `web.Request` object
 
 
 Return types

--- a/src/main/php/web/rest/Delegate.class.php
+++ b/src/main/php/web/rest/Delegate.class.php
@@ -24,12 +24,6 @@ class Delegate {
         }
         return Streams::readAll($stream);
       },
-      'payload'  => function($req, $format, $name) {
-        return $req->param($name) ?? $req->value($name) ?? $req->header($name) ?? $format->read($req, $name);
-      },
-      'default'  => function($req, $format, $name) {
-        return $req->param($name) ?? $req->value($name) ?? $req->header($name) ?? null;
-      }
     ];
   }
 
@@ -56,14 +50,13 @@ class Delegate {
       // Source derived from parameter type
       $type= $param->getType();
       if ('var' === $type->getName()) {
-        $this->param($param, $param->getName(), $source);
+        // NOOP
       } else if ($type->isAssignableFrom(InputStream::class)) {
-        $this->param($param, $param->getName(), 'stream');
+        $source= 'stream';
       } else if ($type->isAssignableFrom(Request::class)) {
-        $this->param($param, $param->getName(), 'request');
-      } else {
-        $this->param($param, $param->getName(), $source);
+        $source= 'request';
       }
+      $this->param($param, $param->getName(), $source);
     }
   }
 

--- a/src/main/php/web/rest/Delegate.class.php
+++ b/src/main/php/web/rest/Delegate.class.php
@@ -24,6 +24,9 @@ class Delegate {
         }
         return Streams::readAll($stream);
       },
+      'payload'  => function($req, $format, $name) {
+        return $req->param($name) ?? $req->value($name) ?? $req->header($name) ?? $format->read($req, $name);
+      },
       'default'  => function($req, $format, $name) {
         return $req->param($name) ?? $req->value($name) ?? $req->header($name) ?? null;
       }
@@ -35,8 +38,9 @@ class Delegate {
    *
    * @param  object $instance
    * @param  lang.reflect.Method $method
+   * @param  string $source Default source
    */
-  public function __construct($instance, $method) {
+  public function __construct($instance, $method, $source) {
     $this->instance= $instance;
     $this->method= $method;
     foreach ($method->getParameters() as $param) {
@@ -44,19 +48,21 @@ class Delegate {
       // Source explicitely set by annotation
       foreach ($param->getAnnotations() as $source => $name) {
         if (isset(self::$SOURCES[$source])) {
-          $this->param($param, $name ?? $param->getName(), self::$SOURCES[$source]);
+          $this->param($param, $name ?? $param->getName(), $source);
           continue 2;
         }
       }
 
       // Source derived from parameter type
       $type= $param->getType();
-      if ($type->isAssignableFrom(InputStream::class)) {
-        $this->param($param, $param->getName(), self::$SOURCES['stream']);
+      if ('var' === $type->getName()) {
+        $this->param($param, $param->getName(), $source);
+      } else if ($type->isAssignableFrom(InputStream::class)) {
+        $this->param($param, $param->getName(), 'stream');
       } else if ($type->isAssignableFrom(Request::class)) {
-        $this->param($param, $param->getName(), self::$SOURCES['request']);
+        $this->param($param, $param->getName(), 'request');
       } else {
-        $this->param($param, $param->getName(), self::$SOURCES['default']);
+        $this->param($param, $param->getName(), $source);
       }
     }
   }
@@ -70,14 +76,16 @@ class Delegate {
    * @return void
    */
   private function param($param, $name, $source) {
+    $extract= self::$SOURCES[$source];
+
     if ($param->isOptional()) {
       $default= $param->getDefaultValue();
-      $read= function($req, $format) use($source, $name, $default) {
-        return $source($req, $format, $name) ?? $default;
+      $read= function($req, $format) use($extract, $name, $default) {
+        return $extract($req, $format, $name) ?? $default;
       };
     } else {
-      $read= function($req, $format) use($source, $name) {
-        if (null === ($value= $source($req, $format, $name))) {
+      $read= function($req, $format) use($extract, $name) {
+        if (null === ($value= $extract($req, $format, $name))) {
           throw new IllegalArgumentException('Missing argument '.$name);
         }
         return $value;

--- a/src/main/php/web/rest/Delegates.class.php
+++ b/src/main/php/web/rest/Delegates.class.php
@@ -7,13 +7,13 @@ use lang\IllegalArgumentException;
  */
 class Delegates {
   private static $METHODS= [
-    'get'     => null,
-    'head'    => null,
-    'post'    => null,
-    'put'     => null,
-    'patch'   => null,
-    'delete'  => null,
-    'options' => null
+    'get'     => 'default',
+    'head'    => 'default',
+    'post'    => 'payload',
+    'put'     => 'payload',
+    'patch'   => 'payload',
+    'delete'  => 'default',
+    'options' => 'default'
   ];
   public $patterns= [];
 
@@ -40,7 +40,7 @@ class Delegates {
         } else {
           $pattern= $base.preg_replace(['/\{([^:}]+):([^}]+)\}/', '/\{([^}]+)\}/'], ['(?<$1>$2)', '(?<$1>[^/]+)'], $segment);
         }
-        $this->patterns['#^'.$verb.$pattern.'$#']= new Delegate($instance, $method);
+        $this->patterns['#^'.$verb.$pattern.'$#']= new Delegate($instance, $method, self::$METHODS[$verb]);
       }
     }
     return $this;

--- a/src/main/php/web/rest/Delegates.class.php
+++ b/src/main/php/web/rest/Delegates.class.php
@@ -7,13 +7,13 @@ use lang\IllegalArgumentException;
  */
 class Delegates {
   private static $METHODS= [
-    'get'     => 'default',
-    'head'    => 'default',
-    'post'    => 'payload',
-    'put'     => 'payload',
-    'patch'   => 'payload',
-    'delete'  => 'default',
-    'options' => 'default'
+    'get'     => 'param',
+    'head'    => 'param',
+    'post'    => 'entity',
+    'put'     => 'entity',
+    'patch'   => 'entity',
+    'delete'  => 'param',
+    'options' => 'param'
   ];
   public $patterns= [];
 

--- a/src/test/php/web/rest/unittest/api/Users.class.php
+++ b/src/test/php/web/rest/unittest/api/Users.class.php
@@ -3,7 +3,7 @@
 use io\streams\{InputStream, MemoryInputStream};
 use lang\ElementNotFoundException;
 use web\Error;
-use web\rest\{Response, Resource, Cached, Get, Post, Delete, Put, Entity};
+use web\rest\{Response, Resource, Get, Post, Delete, Put};
 
 #[Resource('/users')]
 class Users {
@@ -33,10 +33,7 @@ class Users {
   }
 
   #[Post('/')]
-  public function newUser(
-    #[Entity]
-    $user
-  ) {
+  public function newUser($user) {
     end($this->users);
     $id= key($this->users) + 1;
     $new= ['id' => $id, 'name' => $user['name']]; 


### PR DESCRIPTION
With this pull request, it's no longer be necessary to supply parameter annotations for the typical case.

```php
use web\rest\{Get, Post, Resource, Response};

#[Resource('/users')]
class Users {

  #[Get('/')]
  public function listUsers($max= 10) {
    // ...
  }

  #[Get('/{id}')]
  public function getUser($id) {
    // ...
  }

  #[Post('/')]
  public function createUser($user) {
    // ...
    return Response::created('/users/'.$id)->entity($created);
  }
}
```

*Previously, the above example required annotations on listUsers()'s `$max` and on on createUser()'s `$user` parameters*.

The defaults differ based on the HTTP method used:

* For GET, HEAD, DELETE and OPTIONS, default to checking parameters. **Does not check values any longer ⚠️**
* For POST, PUT and PATCH requests, default to checking entity

See also https://stackoverflow.com/questions/5905916/payloads-of-http-request-methods