### PR TITLE
Expand curly braces inside location

### DIFF
--- a/src/main/php/web/rest/Response.class.php
+++ b/src/main/php/web/rest/Response.class.php
@@ -27,15 +27,35 @@ class Response {
   }
 
   /**
+   * Expands segments inside a given location
+   *
+   * @param  string $location
+   * @param  array $arguments
+   * @return string
+   */
+  private static function expand($location, $arguments) {
+    if (empty($arguments)) return $location;
+    $i= 0;
+    return preg_replace_callback(
+      '/{([^}]+)}/',
+      function($matches) use($arguments, &$i) { return rawurlencode($arguments[$matches[1]] ?? $arguments[$i++]); },
+      $location
+    );
+  }
+
+  /**
    * Creates a new response instance with the status code set to 201 (Created)
    * and an optional location.
    *
    * @param  string $location
+   * @param  var... $arguments
    * @return self
    */
-  public static function created($location= null) {
+  public static function created($location= null, ... $arguments) {
     $self= new self(201);
-    if (null !== $location) $self->headers['Location']= $location;
+    if (null !== $location) {
+      $self->headers['Location']= self::expand($location, $arguments);
+    }
     return $self;
   }
 
@@ -53,11 +73,12 @@ class Response {
    * and a specified location.
    *
    * @param  string $location
+   * @param  var... $arguments
    * @return self
    */
-  public static function see($location) {
+  public static function see($location, ... $arguments) {
     $self= new self(302);
-    $self->headers['Location']= $location;
+    $self->headers['Location']= self::expand($location, $arguments);
     return $self;
   }
 

--- a/src/test/php/web/rest/unittest/ResponseTest.class.php
+++ b/src/test/php/web/rest/unittest/ResponseTest.class.php
@@ -32,6 +32,14 @@ class ResponseTest extends TestCase {
   }
 
   #[Test]
+  public function created_with_location_and_arguments() {
+    $this->assertEquals(
+      ['status' => 201, 'headers' => ['Location' => '/users/~friebe/avatars/1'], 'body' => null],
+      Response::created('/users/{user}/avatars/{id}', '~friebe', 1)->export()
+    );
+  }
+
+  #[Test]
   public function no_content() {
     $this->assertEquals(
       ['status' => 204, 'headers' => [], 'body' => null],
@@ -44,6 +52,14 @@ class ResponseTest extends TestCase {
     $this->assertEquals(
       ['status' => 302, 'headers' => ['Location' => self::URI], 'body' => null],
       Response::see(self::URI)->export()
+    );
+  }
+
+  #[Test]
+  public function see_with_arguments() {
+    $this->assertEquals(
+      ['status' => 302, 'headers' => ['Location' => '/users/~friebe/avatars/1'], 'body' => null],
+      Response::see('/users/{user}/avatars/{id}', '~friebe', 1)->export()
     );
   }
 


### PR DESCRIPTION
```php
// Previously, had to rawurlencode() ID manually
return Response::created('/users/'.$created->id())->entity($created);

// Encoding taken care of
return Response::created('/users/{id}', $created->id())->entity($created);

// PHP 8 or XP Compiler: Can even use named arguments, order becomes unimportant
return Response::created('/users/{id}', id: $created->id())->entity($created);
```