### PR TITLE
Send a "HTTP/1.1 100 Continue" if we get a "Expect: 100-continue"

### DIFF
--- a/src/main/php/web/rest/RestApi.class.php
+++ b/src/main/php/web/rest/RestApi.class.php
@@ -113,6 +113,8 @@ class RestApi implements Handler {
       return $this->transmit($res, Response::error(400, $e), $out);
     }
 
+    // We've come here, signal to the client to continue
+    if ('100-continue' === $req->header('Expect')) $res->hint(100, 'Continue');
     $invocation= new Invocation($this->invocations, $delegate);
     try {
       return $this->transmit($res, $invocation->proceed($args), $out);

--- a/src/test/php/web/rest/unittest/RestApiTest.class.php
+++ b/src/test/php/web/rest/unittest/RestApiTest.class.php
@@ -35,6 +35,15 @@ class RestApiTest extends RunTest {
   }
 
   #[Test]
+  public function returns_100_continue_if_expect_sent() {
+    $payload= $this->run(new RestApi(new Users()), 'GET', '/users', ['Expect' => '100-continue'])
+      ->output()
+      ->bytes()
+    ;
+    Assert::equals('HTTP/1.1 100 Continue', substr($payload, 0, strpos($payload, "\r\n")));
+  }
+
+  #[Test]
   public function count_users_returns_json() {
     $res= $this->run(new RestApi(new Users()), 'GET', '/users/count');
     $this->assertPayload(200, 'application/json', '2', $res);


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/100