### PR TITLE
Add support for asynchronously running handler code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^11.0 | ^10.0 | ^9.0 | ^8.0 | ^7.0",
-    "xp-forge/web": "^3.0 | ^2.0 | ^1.0",
+    "xp-forge/web": "dev-refactor/async-io as 3.5.0",
     "xp-forge/marshalling": "^1.0 | ^0.3 | ^0.2",
     "xp-forge/json": "^5.0 | ^4.0 | ^3.1",
     "php": ">=7.0.0"

--- a/src/main/php/web/rest/Async.class.php
+++ b/src/main/php/web/rest/Async.class.php
@@ -1,0 +1,19 @@
+<?php namespace web\rest;
+
+use Generator;
+
+/** @test web.rest.unittest.AsyncTest */
+class Async {
+  private $handler;
+
+  /** Creates a new async from a given callable */
+  public function __construct(callable $handler) {
+    $this->handler= $handler;
+  }
+
+  /** Executes handler and returns awaitable */
+  public function awaitable(): Generator {
+    $r= ($this->handler)();
+    return $r instanceof Generator ? $r : (function() use($r) { return $r; yield; })();
+  }
+}

--- a/src/main/php/web/rest/RestApi.class.php
+++ b/src/main/php/web/rest/RestApi.class.php
@@ -72,6 +72,10 @@ class RestApi implements Handler {
   private function transmit($res, $result, $format) {
     if ($result instanceof Response) {
       $result->transmit($res, $format, $this->marshalling);
+    } else if ($result instanceof Async) {
+      $routine= $result->awaitable();
+      yield from $routine;
+      yield from $this->transmit($res, $routine->getReturn(), $format);
     } else {
       $format->transmit($res, $this->marshalling->marshal($result));
     }

--- a/src/test/php/web/rest/unittest/AsyncTest.class.php
+++ b/src/test/php/web/rest/unittest/AsyncTest.class.php
@@ -1,0 +1,54 @@
+<?php namespace web\rest\unittest;
+
+use unittest\{Assert, Expect, Test};
+use web\rest\{Async, RestApi, Get, Response};
+
+class AsyncTest extends RunTest {
+
+  #[Test]
+  public function async_returning_response() {
+    $res= $this->run(new RestApi(new class() {
+
+      #[Get('/')]
+      public function run() {
+        return new Async(function() {
+          yield;
+          return Response::noContent();
+        });
+      }
+    }));
+
+    Assert::equals(204, $res->status());
+  }
+
+  #[Test]
+  public function async_returning_value() {
+    $res= $this->run(new RestApi(new class() {
+
+      #[Get('/')]
+      public function run() {
+        return new Async(function() {
+          yield;
+          return ['success' => true];
+        });
+      }
+    }));
+
+    $this->assertPayload(200, 'application/json', '{"success":true}', $res);
+  }
+
+  #[Test]
+  public function async_without_yield() {
+    $res= $this->run(new RestApi(new class() {
+
+      #[Get('/')]
+      public function run() {
+        return new Async(function() {
+          return Response::ok();
+        });
+      }
+    }));
+
+    Assert::equals(200, $res->status());
+  }
+}

--- a/src/test/php/web/rest/unittest/RunTest.class.php
+++ b/src/test/php/web/rest/unittest/RunTest.class.php
@@ -34,11 +34,11 @@ abstract class RunTest {
    * @param  string $body
    * @return web.Response
    */
-  protected function run($api, $method, $uri, $headers= [], $body= '') {
+  protected function run($api, $method= 'GET', $uri= '/', $headers= [], $body= '') {
     $req= new Request(new TestInput($method, $uri, $headers, $body));
     $res= new Response(new TestOutput());
 
-    $api->handle($req, $res);
+    foreach ($api->handle($req, $res) ?? [] as $_) { }
     return $res;
   }
 }


### PR DESCRIPTION
The following code will run the upload function asynchronously, continuing to serve requests while file contents are being transmitted.

```php
use io\Folder;
use web\rest\{Post, Response};

class Uploads {
  public function __construct(private Folder $folder) { }

  #[Post('/files')]
  public function upload(#[Request] $req) {
    return new Async(function() use($req) {
      if ($multipart= $req->multipart()) {

        foreach ($multipart->files() as $file) {
          yield from $file->transmit($this->folder);
        }
      }

      return Response::ok();
    });
  }
}
```
