### PR TITLE
Add Response::yield() which uses generators to produce the response entity

### DIFF
--- a/src/main/php/web/rest/Response.class.php
+++ b/src/main/php/web/rest/Response.class.php
@@ -1,5 +1,6 @@
 <?php namespace web\rest;
 
+use Closure;
 use lang\Throwable;
 
 /**
@@ -209,6 +210,20 @@ class Response {
       $out= $res->stream(strlen($bytes));
       $out->write($bytes);
       $out->close();
+    };
+    return $this;
+  }
+
+  /**
+   * Sends given iterable
+   *
+   * @param  function(): iterable|iterable $arg
+   * @return self
+   */
+  public function yield($arg) {
+    $it= $arg instanceof Closure ? $arg() : $arg;
+    $this->body= function($res, $format, $marshalling) use($it) {
+      $format->write($res, $marshalling->marshal($it));
     };
     return $this;
   }

--- a/src/main/php/web/rest/RestApi.class.php
+++ b/src/main/php/web/rest/RestApi.class.php
@@ -1,5 +1,6 @@
 <?php namespace web\rest;
 
+use Generator;
 use lang\{IllegalArgumentException, Throwable};
 use util\data\Marshalling;
 use web\rest\format\{EntityFormat, FormUrlEncoded, Json, OctetStream};
@@ -72,6 +73,9 @@ class RestApi implements Handler {
   private function transmit($res, $result, $format) {
     if ($result instanceof Response) {
       $result->transmit($res, $format, $this->marshalling);
+    } else if ($result instanceof Generator) {
+      yield from $result;
+      yield from $this->transmit($res, $result->getReturn(), $format);
     } else {
       $format->transmit($res, $this->marshalling->marshal($result));
     }

--- a/src/test/php/web/rest/unittest/RunTest.class.php
+++ b/src/test/php/web/rest/unittest/RunTest.class.php
@@ -38,7 +38,7 @@ abstract class RunTest {
     $req= new Request(new TestInput($method, $uri, $headers, $body));
     $res= new Response(new TestOutput());
 
-    $api->handle($req, $res);
+    foreach ($api->handle($req, $res) ?? [] as $_) { }
     return $res;
   }
 }

--- a/src/test/php/web/rest/unittest/api/Users.class.php
+++ b/src/test/php/web/rest/unittest/api/Users.class.php
@@ -14,8 +14,7 @@ class Users {
 
   #[Get('/')]
   public function listUsers() {
-    yield 1549 => $this->users[1549];
-    yield 6100 => $this->users[6100];
+    return $this->users;
   }
 
   #[Get('/count')]


### PR DESCRIPTION
This pull request changes the handling of generators. While they previously simply produced an entity, they will now serve asynchronous needs. Unlike #17, this is a BC break, and code using `yield` inside a handler function or returning a generator from a handler function will need to be rewritten.

```php
use web\rest\{Get, Response};

class Repository {
  public function users() { yield ... ; }
}

// Old code
#[Resource('/api/users')]
class Users {

  #[Get('/')]
  public function all() {
    return $this->respository->users();
  }
}

// New code
#[Resource('/api/users')]
class Users {

  #[Get('/')]
  public function all() {
    return Response::ok()->yield($this->respository->users());
  }
}
```

However, due to this refactoring, we can now use `yield` for asynchronous purposes. The following code will run the upload function asynchronously, continuing to serve requests while file contents are being transmitted:

```php
use io\Folder;
use web\rest\{Post, Resource, Request, Response};

#[Resource('/api/files')]
class Uploads {
  public function __construct(private Folder $folder) { }

  #[Post('/')]
  public function upload(#[Request] $req) {
    if ($multipart= $req->multipart()) {

      foreach ($multipart->files() as $file) {
        yield from $file->transmit($this->folder);
      }
    }

    return Response::ok();
  }
}
```