### PR TITLE
Change Response::stream() to use async APIs

### DIFF
--- a/src/main/php/web/rest/RestApi.class.php
+++ b/src/main/php/web/rest/RestApi.class.php
@@ -72,8 +72,9 @@ class RestApi implements Handler {
   private function transmit($res, $result, $format) {
     $res->header('X-Content-Type-Options', 'nosniff');
     $res->header('Cache-Control', 'no-cache');
+
     if ($result instanceof Response) {
-      $result->transmit($res, $format, $this->marshalling);
+      yield from $result->transmit($res, $format, $this->marshalling);
     } else if ($result instanceof Async) {
       $routine= $result->awaitable();
       yield from $routine;


### PR DESCRIPTION
Currently, the following code will block the server until all bytes from the given file has been transferred:

```php
#[Resource('/api/entries')]
class Entries {
  public function __construct(private Storage $storage) { }

  #[Get('/{id:.+(/.+)?}/images/{name}')]
  public function media(#[Value] $user, string $id, string $name) {
    $f= new File($this->storage->folder($id), $name);
    if ($f->exists()) {
      return Response::ok()->stream($f->in(), $f->size());
    } else {
      return Response::error(404, 'No media named "'.$name.'" in '.$id);
    }
  }
}
```

With this pull request in place, this will change to use the asynchronous `web.Response::transmit()` by default and no longer block. **No code change is necessary.**