### PR TITLE
Migrate to new reflection library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^11.0 | ^10.0 | ^9.0 | ^8.0 | ^7.0",
+    "xp-framework/reflection": "^2.0",
     "xp-forge/web": "^3.0 | ^2.0 | ^1.0",
     "xp-forge/marshalling": "^1.0 | ^0.3 | ^0.2",
     "xp-forge/json": "^5.0 | ^4.0 | ^3.1",

--- a/src/main/php/web/rest/Delegate.class.php
+++ b/src/main/php/web/rest/Delegate.class.php
@@ -61,12 +61,13 @@ class Delegate {
   }
 
   /**
-   * Adds parameter request reader for a given parameter
+   * Adds parameter request accessor for a given parameter
    *
    * @param  lang.reflection.Parameter $param
    * @param  string $name
    * @param  function(web.Request, web.rest.format.EntityFormat, string): var $accessor
    * @return void
+   * @throws lang.IllegalArgumentException
    */
   private function param($param, $name, $accessor) {
     if ($param->optional()) {
@@ -88,7 +89,7 @@ class Delegate {
   /** @return string */
   public function name() { return nameof($this->instance).'::'.$this->method->name(); }
 
-  /** @return [:var] */
+  /** @return lang.reflection.Annotations */
   public function annotations() { return $this->method->annotations(); }
 
   /** @return [:var] */

--- a/src/main/php/web/rest/MethodsIn.class.php
+++ b/src/main/php/web/rest/MethodsIn.class.php
@@ -1,5 +1,7 @@
 <?php namespace web\rest;
 
+use lang\Reflection;
+
 /**
  * Creates routing based on a given instance
  */
@@ -7,8 +9,12 @@ class MethodsIn extends Delegates {
 
   /** @param object $instance */
   public function __construct($instance) {
-    $class= typeof($instance);
-    $this->with($instance, $class->hasAnnotation('resource') ? $class->getAnnotation('resource') ?? '' : '/');
+    $class= Reflection::type($instance);
+    if ($annotation= $class->annotation(Resource::class)) {
+      $this->with($instance, (string)$annotation->argument(0));
+    } else {
+      $this->with($instance, '/');
+    }
     uksort($this->patterns, function($a, $b) { return strlen($b) - strlen($a); });
   }
 }

--- a/src/main/php/web/rest/ResourcesIn.class.php
+++ b/src/main/php/web/rest/ResourcesIn.class.php
@@ -12,7 +12,7 @@ class ResourcesIn extends Delegates {
   /**
    * Creates this delegates instance
    *
-   * @param  lang.reflect.Package|string $package
+   * @param  lang.reflection.Package|string $package
    * @param  function(lang.XPClass): object $new Optional function to create instances
    */
   public function __construct($package, $new= null) {

--- a/src/main/php/web/rest/ResourcesIn.class.php
+++ b/src/main/php/web/rest/ResourcesIn.class.php
@@ -1,11 +1,11 @@
 <?php namespace web\rest;
 
-use lang\reflect\Package;
+use lang\reflection\Package;
 
 /**
  * Creates routing based on resource classes in a given package
  *
- * @test  xp://web.rest.unittest.ResourcesInTest
+ * @test  web.rest.unittest.ResourcesInTest
  */
 class ResourcesIn extends Delegates {
 
@@ -16,10 +16,10 @@ class ResourcesIn extends Delegates {
    * @param  function(lang.XPClass): object $new Optional function to create instances
    */
   public function __construct($package, $new= null) {
-    $p= $package instanceof Package ? $package : Package::forName($package);
-    foreach ($p->getClasses() as $class) {
-      if ($class->hasAnnotation('resource')) {
-        $this->with($new ? $new($class) : $class->newInstance(), $class->getAnnotation('resource') ?? '');
+    $p= $package instanceof Package ? $package : new Package($package);
+    foreach ($p->types() as $type) {
+      if ($resource= $type->annotation(Resource::class)) {
+        $this->with($new ? $new($type->class()) : $type->newInstance(), (string)$resource->argument(0));
       }
     }
     uksort($this->patterns, function($a, $b) { return strlen($b) - strlen($a); });

--- a/src/test/php/web/rest/unittest/InvocationsTest.class.php
+++ b/src/test/php/web/rest/unittest/InvocationsTest.class.php
@@ -2,7 +2,7 @@
 
 use lang\{ElementNotFoundException, IllegalStateException};
 use test\{Assert, Test};
-use web\rest\unittest\api\Users;
+use web\rest\unittest\api\{Users, Cached};
 use web\rest\{Interceptor, Response, RestApi};
 
 class InvocationsTest extends RunTest {
@@ -49,12 +49,12 @@ class InvocationsTest extends RunTest {
   #[Test]
   public function intercepting_can_access_annotations() {
     $invocations= function($invocation, $args) use(&$cached) {
-      $cached= $invocation->target()->annotations()['cached'];
+      $cached= $invocation->target()->annotations()->type(Cached::class);
       return $invocation->proceed($args);
     };
 
     $this->run((new RestApi(new Users()))->intercepting($invocations), 'GET', '/users/1549/avatar');
-    Assert::equals(['ttl' => 3600], $cached);
+    Assert::equals(['ttl' => 3600], $cached->arguments());
   }
 
   #[Test]

--- a/src/test/php/web/rest/unittest/ResourcesInTest.class.php
+++ b/src/test/php/web/rest/unittest/ResourcesInTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace web\rest\unittest;
 
-use lang\reflect\Package;
+use lang\reflection\Package;
 use test\{Assert, Test};
 use web\rest\ResourcesIn;
 
@@ -14,7 +14,7 @@ class ResourcesInTest {
 
   #[Test]
   public function using_package_instance() {
-    $r= new ResourcesIn(Package::forName('web.rest.unittest.api'));
+    $r= new ResourcesIn(new Package('web.rest.unittest.api'));
     Assert::notEquals(null, $r->target('get', '/monitoring/status'));
   }
 


### PR DESCRIPTION
This pull request migrates the code to use `xp-framework/reflection`. As this changes the API, we will releases this as a major release, 4.0.0 at the time of writing.

## Performance

No measurable impact.

### Before

```bash
$ xp test src/test/php
# ...
Test cases:  121 succeeded, 1 skipped
Memory used: 4291.82 kB (4345.94 kB peak)
Time taken:  0.061 seconds (0.182 seconds overall)
```

### After

```bash
$ xp test src/test/php
# ...
Test cases:  121 succeeded, 1 skipped
Memory used: 4406.82 kB (4496.78 kB peak)
Time taken:  0.064 seconds (0.188 seconds overall)
```

## See also

* https://github.com/xp-forge/frontend/pull/37
* https://github.com/xp-framework/rfc/issues/338
* https://github.com/xp-framework/core/pull/332